### PR TITLE
improve dstore performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,7 +105,7 @@ matrix:
         - BUILD_DIR="${TRAVIS_BUILD_DIR}/../build"
         - mkdir -p "${BUILD_DIR}"
         - cd "${BUILD_DIR}"
-        - CCC_CXX=clang++-3.8 scan-build-3.8 --status-bugs cmake -DJSON_FOR_MODERN_CXX_INCLUDE_DIR:PATH="${TRAVIS_BUILD_DIR}/../include" -DBUILD_SHARED_LIBS:BOOL=ON "${SOURCE_DIR}"
+        - CCC_CXX=clang++-3.8 scan-build-3.8 --status-bugs cmake -DBUILD_TESTING=FALSE -DJSON_FOR_MODERN_CXX_INCLUDE_DIR:PATH="${TRAVIS_BUILD_DIR}/../include" -DBUILD_SHARED_LIBS:BOOL=ON "${SOURCE_DIR}"
         - CCC_CXX=clang++-3.8 scan-build-3.8 --status-bugs make VERBOSE=1
     - os: linux
       before_install:
@@ -171,7 +171,7 @@ matrix:
         - mkdir -p "${BUILD_DIR}"
         - cd "${BUILD_DIR}"
         - echo "CXXFLAGS='${CXXFLAGS}' LDFLAGS='${LDFLAGS}'"
-        - cmake -DJSON_FOR_MODERN_CXX_INCLUDE_DIR:PATH="${TRAVIS_BUILD_DIR}/../include" -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_BUILD_TYPE=Debug "${SOURCE_DIR}"
+        - cmake -DBUILD_TESTING=FALSE -DJSON_FOR_MODERN_CXX_INCLUDE_DIR:PATH="${TRAVIS_BUILD_DIR}/../include" -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_BUILD_TYPE=Debug "${SOURCE_DIR}"
         - make VERBOSE=1
         - "${TRAVIS_BUILD_DIR}/.travis/ipfs_daemon_start.sh"
         - OK="no"
@@ -199,5 +199,5 @@ script:
   - mkdir -p "${BUILD_DIR}"
   - cd "${BUILD_DIR}"
   - echo "CXXFLAGS='${CXXFLAGS}' LDFLAGS='${LDFLAGS}'"
-  - cmake -DJSON_FOR_MODERN_CXX_INCLUDE_DIR:PATH="${TRAVIS_BUILD_DIR}/../include" -DBUILD_SHARED_LIBS:BOOL=ON "${CMAKE_EXTRA_ARGS_}" "${SOURCE_DIR}"
+  - cmake -DBUILD_TESTING=FALSE -DJSON_FOR_MODERN_CXX_INCLUDE_DIR:PATH="${TRAVIS_BUILD_DIR}/../include" -DBUILD_SHARED_LIBS:BOOL=ON "${CMAKE_EXTRA_ARGS_}" "${SOURCE_DIR}"
   - make VERBOSE=1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ add_definitions(-DCURL_STATICLIB)
 # Find "JSON for Modern C++" (nlohmann/json.hpp)
 include_directories("include/hive")
 
-include_directories("include")
+include_directories(BEFORE "include")
 
 # Targets
 # cpp-hive-api

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,9 @@
+2019/08/05 Li Fenxiang lifenxiang@elastos.org
+
+**Version 0.1.2**, main feature list:
+
+- Improve DStore performance
+
 2019/05/05 Li Fenxiang lifenxiang@elastos.org
 
 **Version 0.1.1**, main feature list:

--- a/README.md
+++ b/README.md
@@ -68,14 +68,14 @@ $ cd build
 Generate the Makefile in the current directory:
 
 ```shell
-$ cmake ..
+$ cmake -DBUILD_TESTING=FALSE ..
 $ make
 ```
 
 To be able to build a distribution and install it to the customized location, run the following commands:
 
 ```shell
-$ cmake -DCMAKE_INSTALL_PREFIX=YOUR-INSTALL-PATH ..
+$ cmake -DBUILD_TESTING=FALSE -DCMAKE_INSTALL_PREFIX=YOUR-INSTALL-PATH ..
 $ make install
 ```
 # Run Tests

--- a/include/hive/c-api.h
+++ b/include/hive/c-api.h
@@ -15,9 +15,15 @@ const char* hive_generate_conf(const char* host, int port);
 const char* hive_refresh_conf(const char* defaultConf);
 const char* hive_random_host(const char* volatileConf);
 
+typedef struct dstorec_node {
+    char *ipv4;
+    char *ipv6;
+    uint16_t port;
+} dstorec_node;
+
 typedef void DStoreC;
 
-DStoreC *dstore_create(const char *hive_conf);
+DStoreC *dstore_create(dstorec_node *bootstraps, size_t sz);
 void dstore_destroy(DStoreC *dstore);
 int dstore_get_values(DStoreC *dstore, const char *key,
                       bool (*cb)(const char *key, const uint8_t *value,

--- a/include/hive/message.h
+++ b/include/hive/message.h
@@ -2,6 +2,8 @@
 #if !defined(__DMMESSAGE_H_)
 #define __DMMESSAGE_H_
 
+#include <vector>
+
 #include <hive/node.h>
 #include <string>
 
@@ -21,9 +23,15 @@ class DMessage {
   std::string content;
 };
 
+typedef struct dstore_node {
+  std::string ipv4;
+  std::string ipv6;
+  uint16_t port;
+} dstore_node;
+
 class DStore {
  public:
-  DStore(const std::string host, int port, bool log = false);
+  explicit DStore(std::vector<dstore_node> &&nodes, bool log = false);
 
   std::string get_peerId();
 
@@ -42,11 +50,20 @@ class DStore {
 
   bool remove_values(const std::string& key);
 
-  bool set_sender_UID(std::string& uid);
-
   void enable_log(bool enable);
 
  private:
+  bool set_sender_UID(std::string& uid);
+
+  std::shared_ptr<std::vector<std::shared_ptr<DMessage>>> get_values_internal(
+      const std::string& key);
+
+  bool add_value_internal(const std::string& key, std::shared_ptr<DMessage> message);
+
+  bool remove_values_internal(const std::string& key);
+
+  bool select_node();
+
   bool publish();
 
   bool resolve();
@@ -60,6 +77,7 @@ class DStore {
   bool needPublish;
   bool needResolve;
   bool debugLog;
+  std::vector<dstore_node> candidate_nodes;
 };
 
 #endif  // __DMMESSAGE_H_

--- a/include/hive/node.h
+++ b/include/hive/node.h
@@ -51,15 +51,17 @@ class Node {
    * @snippet generic.cc ipfs::Node::Node
    *
    * @since version 0.1.0 */
-  Node(
+  explicit Node(
       /** [in] Hostname or IP address of the server to connect to. */
-      const std::string& host,
+      const std::string& host = "localhost",
       /** [in] Port to connect to. */
-      long port);
+      long port = 9095);
 
   /** Destructor.
    * @since version 0.1.0 */
   ~Node();
+
+  void set_addr(const std::string& host, long port);
 
   /** Return the identity of the peer.
    *

--- a/src/node.cc
+++ b/src/node.cc
@@ -39,6 +39,10 @@ Node::~Node() { delete http_; }
 
 void Node::Id(Json* id) { FetchAndParseJson(MakeUrl("id"), id); }
 
+void Node::set_addr(const std::string& host, long port) {
+  url_prefix_ = "http://" + host + ":" + std::to_string(port) + "/api/v0";
+}
+
 void Node::Version(Json* version) {
   FetchAndParseJson(MakeUrl("version"), version);
 }


### PR DESCRIPTION
enable configuring multiple hive ipfs nodes through dstore_create(), and randomly select one as working node. working node is re-selected if the current one stops working.